### PR TITLE
Feature/config deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ For additional functionality see the output from `manage-cluster -h`:
   manage-cluster -v        prints the 'manage-cluster' version
 
   COMMAND:
-    template     creates a template cluster configuration directory
-    deploy       creates virtual machines
-    deploy-k8s   deploys kubernetes
-    destroy      destroys virtual machines
-    config       configures kubectl
-    shell        opens a shell in the manage-cluster container
+    template       creates a template cluster configuration directory
+    deploy         creates virtual machines
+    deploy-k8s     deploys kubernetes
+    config-cluster customize cluster with CRS4-specific configuration
+    destroy        destroys virtual machines
+    config         configures kubectl
+    shell          opens a shell in the manage-cluster container
 
   CLUSTER_DIR:
     Path to the directory containing the cluster's configuration
@@ -76,43 +77,6 @@ For additional functionality see the output from `manage-cluster -h`:
 For details about what manage-cluster does, check out
 https://github.com/kubernetes-incubator/kubespray/tree/master/contrib/terraform/openstack
 
-
-## Troubleshooting
-
-### Helm
-
-When using Helm for the first time, the following error can occur:
-```
-Error: configmaps is forbidden: User "system:serviceaccount:kube-system:default" cannot list configmaps in the namespace "kube-system"
-```
-
-In order to fix it type:
-
-```
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-helm init --service-account tiller --upgrade
-```
-(ref: https://stackoverflow.com/questions/46672523/helm-list-cannot-list-configmaps-in-the-namespace-kube-system)
-
-### Pods stuck in pending state
-
-Pods whose definition includes volumes might get stuck in pending state if a (specific or, at least, default) StorageClass has not been defined on the Kubernetes cluster. To define a StorageClass which relies on Cinder (the OpenStack Block Storage service) type:
-
-```
-kubectl create -f storageclass.yaml
-```
-
-
-Another solution is to enable persistent volumes by default, editing the <CLUSTER-CONFIG-DIR>/tf/group_vars/k8s-cluster/k8s-cluster.yml KubeSpray config file:
-
-```
-
-# Add Persistent Volumes Storage Class for corresponding cloud provider ( OpenStack is only supported now )
- persistent_volumes_enabled: true
-
-```
 
 ## Copyright and License
 

--- a/docker/config-cluster/config-cluster-playbook.yml
+++ b/docker/config-cluster/config-cluster-playbook.yml
@@ -26,7 +26,7 @@
   roles:
     - { role: kubespray-defaults}
   tasks:
-    - include: tasks/k8s-cluster.yml
+    - include_tasks: tasks/k8s-cluster.yml
 
 - hosts: kube-master
   name: Global k8s-master configuration tasks
@@ -35,7 +35,7 @@
   roles:
     - { role: kubespray-defaults}
   tasks:
-    - include: tasks/k8s-master.yml
+    - include_tasks: tasks/k8s-master.yml
 
 - hosts: kube-node
   name: Global k8s-node configuration tasks
@@ -44,4 +44,4 @@
   roles:
     - { role: kubespray-defaults}
   tasks:
-    - include: tasks/k8s-node.yml
+    - include_tasks: tasks/k8s-node.yml

--- a/docker/config-cluster/config-cluster-playbook.yml
+++ b/docker/config-cluster/config-cluster-playbook.yml
@@ -1,4 +1,7 @@
 ---
+
+#ansible-playbook -v --become -i hosts.ini --timeout 30 config-cluster-playbook.yml
+
 - hosts: localhost
   gather_facts: false
   tasks:
@@ -20,7 +23,7 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
 
 - hosts: k8s-cluster
-  name: Global k8s-cluster configuration tasks
+  name: Global k8s-cluster node configuration tasks
   become: yes
   gather_facts: true
   roles:
@@ -29,7 +32,7 @@
     - include_tasks: tasks/k8s-cluster.yml
 
 - hosts: kube-master
-  name: Global k8s-master configuration tasks
+  name: Global k8s-master node configuration tasks
   become: yes
   gather_facts: true
   roles:
@@ -38,12 +41,32 @@
     - include_tasks: tasks/k8s-master.yml
 
 - hosts: kube-node
-  name: Global k8s-node configuration tasks
+  name: Global k8s-node node configuration tasks
   become: yes
   gather_facts: true
+  strategy: free
   vars:
     - n_local_volumes: 10
   roles:
     - { role: kubespray-defaults}
   tasks:
     - include_tasks: tasks/k8s-node.yml
+
+- hosts: kube-master[0]
+  tags:
+    - k8sconf
+  name: k8s deployment configuration tasks
+  become: yes
+  gather_facts: false
+  vars:
+    helm:
+      version: v2.13.0
+      checksum: "sha256:15eca6ad225a8279de80c7ced42305e24bc5ac60bb7d96f2d2fa4af86e02c794"
+    local_provisioner:
+      version: v2.3.0
+      checksum: "sha256:d299b30e3c0728ab699acc10f42e4f16d9e5cb8c7395cfc006f9e4ee01c0c563"
+  roles:
+    - { role: kubespray-defaults}
+  tasks:
+    - include_tasks: tasks/k8s-deployment-config.yml
+

--- a/docker/config-cluster/config-cluster-playbook.yml
+++ b/docker/config-cluster/config-cluster-playbook.yml
@@ -65,6 +65,8 @@
     local_provisioner:
       version: v2.3.0
       checksum: "sha256:d299b30e3c0728ab699acc10f42e4f16d9e5cb8c7395cfc006f9e4ee01c0c563"
+    nfs_provisioner:
+      version: 0.2.1
   roles:
     - { role: kubespray-defaults}
   tasks:

--- a/docker/config-cluster/config-cluster-playbook.yml
+++ b/docker/config-cluster/config-cluster-playbook.yml
@@ -41,6 +41,8 @@
   name: Global k8s-node configuration tasks
   become: yes
   gather_facts: true
+  vars:
+    - n_local_volumes: 10
   roles:
     - { role: kubespray-defaults}
   tasks:

--- a/docker/config-cluster/helm-resources/nfs-server-provisioner_values.yml
+++ b/docker/config-cluster/helm-resources/nfs-server-provisioner_values.yml
@@ -1,0 +1,9 @@
+
+persistence:
+  enabled: true
+  storageClass: "cinder-delete"
+  size: 5Gi
+
+storageClass:
+  create: true
+  reclaimPolicy: Delete

--- a/docker/config-cluster/helm-resources/sig-storage-local-static-provisioner_values.yml
+++ b/docker/config-cluster/helm-resources/sig-storage-local-static-provisioner_values.yml
@@ -1,8 +1,8 @@
 
-# helm template --values sig-storage-local-static-provisioner_values.yml  ~/Projects/sig-storage-local-static-provisioner/helm/provisioner > provisioner_generated.yaml
-
 common:
-  # must be kube-system.  Otherwise you need to lower the pod priority
+  # Must be kube-system.  Otherwise you need to lower the pod priority
+  # Note that unless you specify --namespace kube-system the helm release will still be
+  # installed in the default namespace.
   namespace: kube-system
 
 classes:

--- a/docker/config-cluster/helm-resources/sig-storage-local-static-provisioner_values.yml
+++ b/docker/config-cluster/helm-resources/sig-storage-local-static-provisioner_values.yml
@@ -1,0 +1,18 @@
+
+# helm template --values sig-storage-local-static-provisioner_values.yml  ~/Projects/sig-storage-local-static-provisioner/helm/provisioner > provisioner_generated.yaml
+
+common:
+  # must be kube-system.  Otherwise you need to lower the pod priority
+  namespace: kube-system
+
+classes:
+  # Want more than one class?  They must point to different paths
+  - name: eph-delete
+    hostDir: /mnt/eph_scratch
+  - name: eph-retain
+    hostDir: /mnt/eph_retain
+    blockCleanerCommand:
+      - ""
+
+#daemonset:
+#  nodeSelector: {}

--- a/docker/config-cluster/k8s-resources/sa-tiller.yml
+++ b/docker/config-cluster/k8s-resources/sa-tiller.yml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20,6 +21,6 @@ subjects:
   namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: system:cluster-admin
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 

--- a/docker/config-cluster/k8s-resources/sa-tiller.yml
+++ b/docker/config-cluster/k8s-resources/sa-tiller.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+  labels:
+    heritage: "manage-cluster"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller-cluster-rule 
+  labels:
+    heritage: "manage-cluster"
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/docker/config-cluster/k8s-resources/sc-cinder.yml
+++ b/docker/config-cluster/k8s-resources/sc-cinder.yml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cinder-delete
+  labels:
+    heritage: "manage-cluster"
+  annotations:
+    "storageclass.kubernetes.io/is-default-class": "true"
+provisioner: kubernetes.io/cinder
+reclaimPolicy: Delete
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cinder-retain
+  labels:
+    heritage: "manage-cluster"
+provisioner: kubernetes.io/cinder
+reclaimPolicy: Retain

--- a/docker/config-cluster/k8s-resources/sc-eph.yml
+++ b/docker/config-cluster/k8s-resources/sc-eph.yml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: eph-delete
+  labels:
+    heritage: "manage-cluster"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: eph-retain
+  labels:
+    heritage: "manage-cluster"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain

--- a/docker/config-cluster/k8s-resources/sc-standard.yml
+++ b/docker/config-cluster/k8s-resources/sc-standard.yml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+  labels:
+    heritage: "manage-cluster"
+provisioner: kubernetes.io/cinder

--- a/docker/config-cluster/tasks/k8s-cluster.yml
+++ b/docker/config-cluster/tasks/k8s-cluster.yml
@@ -1,4 +1,7 @@
 ---
 - name: Install Ubuntu or Debian node requirements
-  raw: apt-get update && apt-get -y install nfs-client vim
-  when: ansible_facts['os_family'] == "Debian"
+  apt:
+    update_cache: yes
+    name:
+      - nfs-client
+      - vim

--- a/docker/config-cluster/tasks/k8s-cluster.yml
+++ b/docker/config-cluster/tasks/k8s-cluster.yml
@@ -1,11 +1,4 @@
 ---
-- name: Fetch os-release
-  raw: cat /etc/os-release
-  register: os_release
-  changed_when: false
-  environment: {}
-
 - name: Install Ubuntu or Debian node requirements
   raw: apt-get update && apt-get -y install nfs-client vim
-  ignore_errors: yes
-  when: '"Ubuntu" in os_release.stdout or "Debian" in os_release.stdout'
+  when: ansible_facts['os_family'] == "Debian"

--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -1,0 +1,137 @@
+---
+
+### install helm executable
+- name: "Check helm executable"
+  shell: helm version --client --short | grep "{{ helm.version }}"
+  register: helm_client_ok
+  ignore_errors: True
+  changed_when: False
+
+- name: print message
+  debug:
+    msg: "{{ [ '', 'found helm executable on master', '' ] }}"
+  when: helm_client_ok is succeeded
+
+
+- name: print message
+  debug:
+    msg: "{{ [ '', 'installing helm executable on master node', '' ] }}"
+  when: helm_client_ok is failed
+
+- name: Create temporary directory for helm download
+  tempfile:
+    state: directory
+  register: output
+  when: helm_client_ok is failed
+
+- name: "Download helm {{ helm.version }}"
+  get_url:
+    checksum: "{{ helm.checksum }}"
+    dest: "{{ output.path }}/helm_archive.tar.gz"
+    url: "https://storage.googleapis.com/kubernetes-helm/helm-{{ helm.version }}-linux-amd64.tar.gz"
+  when: helm_client_ok is failed
+
+- name: Extract helm
+  unarchive:
+    src: "{{ output.path }}/helm_archive.tar.gz"
+    copy: no
+    creates: "{{ output.path }}/linux-amd64/helm"
+    dest: "{{ output.path }}"
+  when: helm_client_ok is failed
+
+- name: stat helm executable
+  stat:
+    path: "{{ output.path }}/linux-amd64/helm"
+  register: helm_stat
+  when: helm_client_ok is failed
+
+- name: Install helm executable
+  command: mv "{{ helm_stat.stat.path }}" /usr/local/bin
+  when: helm_client_ok is failed and helm_stat.stat.exists
+
+- name: Set helm owner and permissions
+  file:
+    path: /usr/local/bin/helm
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Remove helm installation directory
+  file:
+    path: "{{ output.path }}"
+    state: absent
+  when: helm_client_ok is failed
+
+###### Install k8s resources
+- name: print message
+  debug:
+    msg: "{{ [ '', 'Installing k8s resources', '' ] }}"
+
+- name: Copy k8s resources to master node
+  copy:
+    src: "{{ playbook_dir }}/k8s-resources"
+    dest: /root/manage-cluster/
+
+- name: list k8s resources on master node
+  find:
+    paths: /root/manage-cluster/k8s-resources
+  register: k8s_resources
+
+- name: Create k8s resources
+  shell: kubectl apply -f "{{ item.path }}"
+  loop: "{{ k8s_resources.files | list }}"
+
+####### Install tiller on cluster
+- name: print message
+  debug:
+    msg: "{{ [ '', 'Installng/upgrading tiller', '' ] }}"
+
+- name: Install or upgrade tiller
+  shell: helm init --service-account tiller --upgrade
+  register: tiller_install_result
+
+- name: Print tiller output
+  debug:
+    msg: "{{ tiller_install_result.stdout.split('\n') }}" # The splitting makes it reproduce the newlines
+
+### Generate template for local storage provisioner
+#- name: Check if provisioner installed
+#  shell: kubectl get pods --all-namespaces=true | grep 
+#  register: helm_client_ok
+#  ignore_errors: True
+#  changed_when: False
+#
+##
+#- name: Create temporary directory for sig-storage-local-static-provisioner download
+#  tempfile:
+#    state: directory
+#  register: output
+#
+#- name: "Name download sig-storage-local-static-provisioner {{ local_provisioner.version }}"
+#  get_url:
+#    checksum: "{{ local_provisioner.checksum }}"
+#    dest: "{{ output.path }}/provisioner_archive.tar.gz"
+#    url: "https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/archive/{{ local_provisioner.version }}.tar.gz"
+#
+#- name: set var
+#  set_fact:
+#    provisioner_path: "{{ output.path }}/sig-storage-local-static-provisioner-{{ local_provisioner.version[1:] }}" 
+#
+#- name: Extract provisioner archive
+#  unarchive:
+#    src: "{{ output.path }}/provisioner_archive.tar.gz"
+#    copy: no
+#    creates: "{{ provisioner_path }}"
+#    dest: "{{ output.path }}"
+#
+#- name: Create provisioner template
+#  shell: >
+#    helm template --values "{{ playbook_dir }}/helm-resources/sig-storage-local-static-provisioner_values.yml"
+#    "{{ provisioner_path }}/helm/provisioner" > k8s-resources/local-static-provisioner.yml.generated
+#
+#- name: Remove tmp provisioner installation directory
+#  file:
+#    path: "{{ output.path }}"
+#    state: absent
+#
+#

--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -99,6 +99,23 @@
     src: "{{ playbook_dir }}/helm-resources"
     dest: /root/manage-cluster/
 
+- name: Install jq
+  apt:
+    update_cache: yes
+    name:
+      - jq
+    install_recommends: no
+
+- name: pause for tiller
+  pause:
+    echo: no
+    seconds: 5
+  changed_when: false
+
+- name: Check that Tiller is ready before continuing
+  shell: test "true" = `kubectl get pods -l name=tiller --all-namespaces --output=json | jq '.["items"][0]["status"]["containerStatuses"][0]["ready"]'`
+  changed_when: false
+
 ### Install  local storage provisioner
 
 - name: Check if local provisioner installed

--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -9,7 +9,7 @@
 
 - name: print message
   debug:
-    msg: "{{ [ '', 'found helm executable on master', '' ] }}"
+    msg: "{{ [ '', 'found helm executable version {{ helm.version }} on master', '' ] }}"
   when: helm_client_ok is succeeded
 
 
@@ -94,44 +94,50 @@
   debug:
     msg: "{{ tiller_install_result.stdout.split('\n') }}" # The splitting makes it reproduce the newlines
 
-### Generate template for local storage provisioner
-#- name: Check if provisioner installed
-#  shell: kubectl get pods --all-namespaces=true | grep 
-#  register: helm_client_ok
-#  ignore_errors: True
-#  changed_when: False
-#
-##
-#- name: Create temporary directory for sig-storage-local-static-provisioner download
-#  tempfile:
-#    state: directory
-#  register: output
-#
-#- name: "Name download sig-storage-local-static-provisioner {{ local_provisioner.version }}"
-#  get_url:
-#    checksum: "{{ local_provisioner.checksum }}"
-#    dest: "{{ output.path }}/provisioner_archive.tar.gz"
-#    url: "https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/archive/{{ local_provisioner.version }}.tar.gz"
-#
-#- name: set var
-#  set_fact:
-#    provisioner_path: "{{ output.path }}/sig-storage-local-static-provisioner-{{ local_provisioner.version[1:] }}" 
-#
-#- name: Extract provisioner archive
-#  unarchive:
-#    src: "{{ output.path }}/provisioner_archive.tar.gz"
-#    copy: no
-#    creates: "{{ provisioner_path }}"
-#    dest: "{{ output.path }}"
-#
-#- name: Create provisioner template
-#  shell: >
-#    helm template --values "{{ playbook_dir }}/helm-resources/sig-storage-local-static-provisioner_values.yml"
-#    "{{ provisioner_path }}/helm/provisioner" > k8s-resources/local-static-provisioner.yml.generated
-#
-#- name: Remove tmp provisioner installation directory
-#  file:
-#    path: "{{ output.path }}"
-#    state: absent
-#
-#
+- name: Copy helm resources to master node
+  copy:
+    src: "{{ playbook_dir }}/helm-resources"
+    dest: /root/manage-cluster/
+
+### Install  local storage provisioner
+
+- name: Check if provisioner installed
+  shell: kubectl get pods -l app=local-volume-provisioner --all-namespaces --output=name | grep -c local-volume-provisioner
+  register: provisioner_ok
+  ignore_errors: True
+  changed_when: False
+
+- name: Create temporary directory for sig-storage-local-static-provisioner download
+  tempfile:
+    state: directory
+  register: output
+  when: provisioner_ok is failed
+
+- name: "Name download sig-storage-local-static-provisioner {{ local_provisioner.version }}"
+  get_url:
+    checksum: "{{ local_provisioner.checksum }}"
+    dest: "{{ output.path }}/provisioner_archive.tar.gz"
+    url: "https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/archive/{{ local_provisioner.version }}.tar.gz"
+  when: provisioner_ok is failed
+
+- name: set var
+  set_fact:
+    provisioner_path: "{{ output.path }}/sig-storage-local-static-provisioner-{{ local_provisioner.version[1:] }}"
+
+- name: Extract provisioner archive
+  unarchive:
+    src: "{{ output.path }}/provisioner_archive.tar.gz"
+    copy: no
+    creates: "{{ provisioner_path }}"
+    dest: "{{ output.path }}"
+  when: provisioner_ok is failed
+
+- name: Install local volume provisioner chart into kube-system namespace
+  command: helm install --namespace kube-system --values /root/manage-cluster/helm-resources/sig-storage-local-static-provisioner_values.yml "{{ provisioner_path }}/helm/provisioner"
+  when: provisioner_ok is failed
+
+- name: Remove provisioner download directory
+  file:
+    path: "{{ output.path }}"
+    state: absent
+  when: provisioner_ok is failed

--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -4,12 +4,12 @@
 - name: "Check helm executable"
   shell: helm version --client --short | grep "{{ helm.version }}"
   register: helm_client_ok
-  ignore_errors: True
+  ignore_errors: true
   changed_when: False
 
 - name: print message
   debug:
-    msg: "{{ [ '', 'found helm executable version {{ helm.version }} on master', '' ] }}"
+    msg: "{{ [ '', 'found helm executable version ' + helm.version + ' on master', '' ] }}"
   when: helm_client_ok is succeeded
 
 
@@ -101,10 +101,10 @@
 
 ### Install  local storage provisioner
 
-- name: Check if provisioner installed
+- name: Check if local provisioner installed
   shell: kubectl get pods -l app=local-volume-provisioner --all-namespaces --output=name | grep -c local-volume-provisioner
   register: provisioner_ok
-  ignore_errors: True
+  ignore_errors: true
   changed_when: False
 
 - name: Create temporary directory for sig-storage-local-static-provisioner download
@@ -123,6 +123,7 @@
 - name: set var
   set_fact:
     provisioner_path: "{{ output.path }}/sig-storage-local-static-provisioner-{{ local_provisioner.version[1:] }}"
+  when: provisioner_ok is failed
 
 - name: Extract provisioner archive
   unarchive:
@@ -141,3 +142,46 @@
     path: "{{ output.path }}"
     state: absent
   when: provisioner_ok is failed
+
+
+### Install NFS provisioner
+
+- name: Get installed nfs provisioner chart
+  # The awk is to get a non-zero exit code on empty output
+  shell: helm list | cut -f 5 | awk 'BEGIN{ rv = 1 }; /\<nfs-server-provisioner/ { n=split($0, name_ver, "-"); print name_ver[n]; rv = 0; }; END{ exit rv }'
+  register: nfs_provisioner_installed
+  ignore_errors: true
+  changed_when: False
+
+- name: Show detected chart version
+  debug:
+    msg: "Detected nfs-server-provisioner version {{ nfs_provisioner_installed.stdout }}"
+  when: nfs_provisioner_installed is succeeded
+
+
+- name: set version fact
+  set_fact:
+    version_ok: false
+  changed_when: false
+
+- name: set version fact if ok
+  set_fact:
+    version_ok: "{{ nfs_provisioner_installed.stdout is version(nfs_provisioner.version, '>=') }}"
+  when: nfs_provisioner_installed is succeeded
+
+- name: Install NFS provisioner for ReadWriteMany volumes
+  command: helm install --debug --namespace kube-system --values /root/manage-cluster/helm-resources/nfs-server-provisioner_values.yml stable/nfs-server-provisioner --version "{{ nfs_provisioner.version }}"
+  when: nfs_provisioner_installed is failed
+
+- name: Fail if unsupported NFS provisioner upgrade
+  fail:
+    msg: "Found nfs provisioner version {{ nfs_provisioner_installed.stdout }} but this playbook doesn' support upgrading the helm chart."
+  when:
+    - nfs_provisioner_installed is succeeded
+    - not version_ok
+
+- debug:
+    msg: "{{ [ '', 'NFS server provisioner chart version ' + nfs_provisioner_installed.stdout + ' was already installed', '' ] }}"
+  when:
+    - nfs_provisioner_installed is succeeded
+    - version_ok

--- a/docker/config-cluster/tasks/k8s-deployment-unconfig.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-unconfig.yml
@@ -1,0 +1,31 @@
+---
+
+- name: "check tiller installed"
+  shell: helm version --server --short
+  register: helm_installed
+  ignore_errors: true
+  changed_when: False
+
+- name: Remove all helm deployments
+  shell: helm list --short | xargs --max-lines=1 --no-run-if-empty helm delete
+  register: helm_output
+  when: helm_installed is succeeded
+
+- name: feedback
+  debug:
+    msg: "{{ helm_output.stdout_lines }}"
+  when: helm_installed is succeeded
+
+- name: Delete all PVCs
+  #shell: kubectl delete pvc --all -n kube-system
+  shell: kubectl get pvc --all-namespaces --output json | kubectl delete -f -
+  register: kubectl_output
+
+- name: feedback
+  debug:
+    msg: "{{ kubectl_output.stdout_lines }}"
+
+- name: pause to give a chance to helm and k8s to remove objects
+  pause:
+    echo: no
+    seconds: 5

--- a/docker/config-cluster/tasks/k8s-node.yml
+++ b/docker/config-cluster/tasks/k8s-node.yml
@@ -43,25 +43,15 @@
   file:
     state: directory
     path: "/mnt/eph0/{{ item.0 }}/{{ item.1 }}"
-  loop: "{{ [ 'retain', 'scratch' ]|product(range(0,10))|list }}"
+  loop: "{{ [ 'retain', 'scratch' ]|product(range(0, n_local_volumes))|list }}"
   when: ephemeral_present is succeeded
 
-- name: Bind mount ephemeral 'retain' subdirectories
+- name: Bind mount ephemeral 'retain' and 'scratch' subdirectories
   mount:
     state: mounted
     opts: bind
-    src: "/mnt/eph0/retain/{{ item }}"
-    path: "/mnt/eph_retain/{{ item }}"
+    src: "/mnt/eph0/{{ item.0 }}/{{ item.1 }}"
+    path: "/mnt/eph_{{ item.0 }}/{{ item.1 }}"
     fstype: auto
-  loop: "{{ range(0,10)|list }}"
-  when: ephemeral_present is succeeded
-
-- name: Bind mount ephemeral 'scratch' subdirectories
-  mount:
-    state: mounted
-    opts: bind
-    src: "/mnt/eph0/scratch/{{ item }}"
-    path: "/mnt/eph_scratch/{{ item }}"
-    fstype: auto
-  loop: "{{ range(0,10)|list }}"
+  loop: "{{ [ 'retain', 'scratch' ]|product(range(0, n_local_volumes))|list }}"
   when: ephemeral_present is succeeded

--- a/docker/config-cluster/tasks/k8s-node.yml
+++ b/docker/config-cluster/tasks/k8s-node.yml
@@ -1,1 +1,67 @@
 ---
+- name: Check whether we have an ephemeral block device
+  shell: blkid /dev/vdb | grep 'LABEL="EPH'
+  register: ephemeral_present
+  ignore_errors: True
+  changed_when: False
+
+- name: Check whether we have a virgin ephemeral volume
+  shell: blkid /dev/vdb | grep 'LABEL="EPHEMERAL' | grep 'TYPE="vfat"'
+  register: ephemeral_vergin
+  ignore_errors: True
+  changed_when: False
+
+- name: Tell user we're not going to format
+  debug:
+    msg: "Ephemeral volume is not 'virgin'. We're not going to format it."
+  when: ephemeral_present is succeeded and ephemeral_vergin is failed
+
+- name: unmount ephemeral volume
+  mount:
+    state: absent
+    path: /mnt
+    src: /dev/vdb
+  when: ephemeral_vergin is succeeded
+
+- name: Create a ext4 filesystem on ephemeral /dev/vdb
+  filesystem:
+    fstype: ext4
+    dev: /dev/vdb
+    opts: -L EPH-FORMATTED
+    force: yes
+  when: ephemeral_vergin is succeeded
+
+- name: Mount ephemeral volume
+  mount:
+    state: mounted
+    src: /dev/vdb
+    path: /mnt/eph0
+    fstype: ext4
+  when: ephemeral_present is succeeded
+
+- name: Create volume directories
+  file:
+    state: directory
+    path: "/mnt/eph0/{{ item.0 }}/{{ item.1 }}"
+  loop: "{{ [ 'retain', 'scratch' ]|product(range(0,10))|list }}"
+  when: ephemeral_present is succeeded
+
+- name: Bind mount ephemeral 'retain' subdirectories
+  mount:
+    state: mounted
+    opts: bind
+    src: "/mnt/eph0/retain/{{ item }}"
+    path: "/mnt/eph_retain/{{ item }}"
+    fstype: auto
+  loop: "{{ range(0,10)|list }}"
+  when: ephemeral_present is succeeded
+
+- name: Bind mount ephemeral 'scratch' subdirectories
+  mount:
+    state: mounted
+    opts: bind
+    src: "/mnt/eph0/scratch/{{ item }}"
+    path: "/mnt/eph_scratch/{{ item }}"
+    fstype: auto
+  loop: "{{ range(0,10)|list }}"
+  when: ephemeral_present is succeeded

--- a/docker/config-cluster/unconfig-cluster-playbook.yml
+++ b/docker/config-cluster/unconfig-cluster-playbook.yml
@@ -1,0 +1,27 @@
+---
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: "Check ansible version !=2.7.0"
+      assert:
+        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        that:
+          - ansible_version.string is version("2.7.0", "!=")
+          - ansible_version.string is version("2.6.0", ">=")
+      tags:
+        - check
+  vars:
+    ansible_connection: local
+
+- hosts: kube-master[0]
+  tags:
+    - k8s-unconf
+  name: k8s deployment clean-up tasks
+  become: yes
+  gather_facts: false
+  roles:
+    - { role: kubespray-defaults}
+  tasks:
+    - include_tasks: tasks/k8s-deployment-unconfig.yml
+

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -186,6 +186,7 @@ ssh_user = "ubuntu"
 number_of_bastions = 0
 #flavor_bastion = "<UUID>"
 flavor_bastion = "0298dfce-aa0f-45d0-91a6-ca8ac2313d94"
+#bastion_allowed_remote_ip = ["0.0.0.0/0"]
 
 # standalone etcds
 number_of_etcd = 0
@@ -362,8 +363,6 @@ END
 
 function config_cluster() {
   debug_log "config_cluster function"
-
-  #### TODO: Add k8s cluster configuration
 
   local keyfile_path="$(get_key_file_path)"
   local cmd=('eval $(ssh-agent -s) ; ' \

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -163,10 +163,10 @@ function gen_template() {
   debug_log "Customizing template"
   debug_log "Setting cloud provider to openstack, turning on metrics, turning off deployment of helm and LV provisioner"
   sed -i -e 's/^[#[:blank:]]*cloud_provider:.*$/cloud_provider: openstack/' "${CLUSTER_DIR}/tf/group_vars/all/all.yml"
-  sed -i \
-    -e 's/^[#[:blank:]]*metrics_server_enabled:.*$/metrics_server_enabled: true/' \
-    -e 's/^[#[:blank:]]*helm_enabled:.*$/helm_enabled: false/' \
-    -e 's/^[#[:blank:]]*local_volume_provisioner_enabled:.*$/local_volume_provisioner_enabled: false/' \
+  sed -i-e \
+    's/^[#[:blank:]]*metrics_server_enabled:.*$/metrics_server_enabled: true/;
+     s/^[#[:blank:]]*helm_enabled:.*$/helm_enabled: false/;
+     s/^[#[:blank:]]*local_volume_provisioner_enabled:.*$/local_volume_provisioner_enabled: false/' \
     "${CLUSTER_DIR}/tf/group_vars/k8s-cluster/addons.yml"
 
   debug_log "Generating cluster.tf template"

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -236,7 +236,7 @@ function init() {
     && echo -en "\nDo you want to continue (y/n)? ") >&2
   read answer
   echo >&2
-  if [[ $answer != "y" ]]; then
+  if [[ "${answer}" != y* ]]; then
     exit 0
   fi
 }
@@ -365,20 +365,53 @@ END
   fi
 }
 
-function config_cluster() {
-  debug_log "config_cluster function"
+function _run_playbook() {
 
+  local playbook_file="${1}"
   local keyfile_path="$(get_key_file_path)"
   local cmd=('eval $(ssh-agent -s) ; ' \
              "mkdir -p /etc/ansible && " \
              "ln -s /kubespray/roles /etc/ansible/roles ;" \
              "ssh-add -k '${keyfile_path}' && " \
-             "ansible-playbook $(ansible_verbosity) --become -i '${InventoryFile}' --timeout 30 config-cluster-playbook.yml")
+             "ansible-playbook $(ansible_verbosity) --become -i '${InventoryFile}' --timeout 30 '${playbook_file}'")
   docker_run_ks /bin/sh -o xtrace -c "${cmd[*]}" # expand cmd and compact into a single string
 }
 
+function config_cluster() {
+  _run_playbook config-cluster-playbook.yml
+}
+
+function unconfig_cluster() {
+  _run_playbook unconfig-cluster-playbook.yml
+}
+
 function destroy_cluster(){
+
+  cat >&2 <<END
+
+
+We are about to deconfigure your cluster (REMOVING PVCs and deployed charts!!!)
+This will be done BEFORE Terraform asks you to confirm the destruction of
+deployed objects.
+
+===============================================================================
+
+                    ARE YOU SURE YOU WANT TO PROCEED?
+
+===============================================================================
+
+END
+
+  printf "Type \"yes\" to confirm: " >&2
+  read answer
+  echo >&2
+  if [[ $answer != "yes" ]]; then
+    log "Aborting destruction"
+    exit 0
+  fi
+
   local master_ip="$(get_master_ip)"
+  unconfig_cluster
   docker_run_tf terraform init ../../contrib/terraform/openstack;
   docker_run_tf terraform destroy -var-file=cluster.tf ../../contrib/terraform/openstack
 

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -158,12 +158,16 @@ function gen_template() {
   docker_run_tf /bin/sh -o xtrace -c \
     "cp --dereference --recursive ${KubesprayContainerDir}/contrib/terraform/openstack/sample-inventory/group_vars . \
      && cp --dereference --recursive /home/manageks/config-cluster/* . \
-     && mkdir roles "
+     && mkdir --parents roles"
 
   debug_log "Customizing template"
-  debug_log "Setting cloud provider to openstack and turning on metrics"
-  sed -i -e 's/^#\{0,1\}[[:space:]]*cloud_provider:.*$/cloud_provider: openstack/' "${CLUSTER_DIR}/tf/group_vars/all/all.yml"
-  sed -i -e 's/^[[:space:]]*metrics_server_enabled:[[:space:]]*false[[:space:]]*$/metrics_server_enabled: true/' "${CLUSTER_DIR}/tf/group_vars/k8s-cluster/addons.yml"
+  debug_log "Setting cloud provider to openstack, turning on metrics, turning off deployment of helm and LV provisioner"
+  sed -i -e 's/^[#[:blank:]]*cloud_provider:.*$/cloud_provider: openstack/' "${CLUSTER_DIR}/tf/group_vars/all/all.yml"
+  sed -i \
+    -e 's/^[#[:blank:]]*metrics_server_enabled:.*$/metrics_server_enabled: true/' \
+    -e 's/^[#[:blank:]]*helm_enabled:.*$/helm_enabled: false/' \
+    -e 's/^[#[:blank:]]*local_volume_provisioner_enabled:.*$/local_volume_provisioner_enabled: false/' \
+    "${CLUSTER_DIR}/tf/group_vars/k8s-cluster/addons.yml"
 
   debug_log "Generating cluster.tf template"
   cat > "${CLUSTER_DIR}/tf/cluster.tf" <<END

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -361,7 +361,9 @@ END
   "
 
   if command -v helm >/dev/null; then
-    helm repo add crs4 https://crs4.github.io/helm-charts/
+    if ! helm repo add crs4 https://crs4.github.io/helm-charts/ 2>/dev/null ; then
+      log "Please initialize helm and add https://crs4.github.io/helm-charts/ to your repositories to install CRS4's charts"
+    fi
   fi
 }
 
@@ -473,6 +475,11 @@ while getopts ":h :v" opt; do
         ;;
   esac
 done
+
+if [[ $# != 2 ]]; then
+  # At this point, we always need at two arguments from the user: subcommand and path
+  usage_error
+fi
 
 # shift arguments forward by the amount processed by getopts
 shift $(($OPTIND - 1))

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -22,7 +22,7 @@ set -o pipefail
 set -o errtrace
 
 # sw version
-VERSION=1.1rc1
+VERSION=1.1rc2
 # set version of docker images
 KsImage="${KsImage:-tdmproject/manage-cluster-ks:${VERSION}}"
 TfImage="${TfImage:-tdmproject/manage-cluster-tf:${VERSION}}"

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -359,6 +359,10 @@ END
 
   OR, you can source ${sourcing_file}
   "
+
+  if command -v helm >/dev/null; then
+    helm repo add crs4 https://crs4.github.io/helm-charts/
+  fi
 }
 
 function config_cluster() {

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -178,7 +178,7 @@ dns_nameservers = ["172.30.3.211", "172.30.3.212"]
 public_key_path = "../artifacts/${defaultSshKeyFile}.pub"
 
 # image to use for bastion, masters, standalone etcd instances, and nodes
-image = "ubuntu-16.04"
+image = "ubuntu-18.04"
 # user on the node (ex. core on Container Linux, ubuntu on Ubuntu, etc.)
 ssh_user = "ubuntu"
 

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -22,7 +22,7 @@ set -o pipefail
 set -o errtrace
 
 # sw version
-VERSION=1.0rc2
+VERSION=1.1rc1
 # set version of docker images
 KsImage="${KsImage:-tdmproject/manage-cluster-ks:${VERSION}}"
 TfImage="${TfImage:-tdmproject/manage-cluster-tf:${VERSION}}"


### PR DESCRIPTION
This PR brings a significant list of ansible tasks to preconfigure the k8s cluster deployed by manage-cluster. In particular, the plays will:
  * Install tiller
  * Configure storage classes for cinder and local volumes (two for each, varying in reclaim policy: one Delete and one Retain)
  * Configure ephemeral storage on the worker nodes to be exposed as local volumes
  * Install the static local volume provisioner
  * Install the NFS server provisioner

As before, the playbook is included in the template generated by `manage-cluster` and is executed with the `config-cluster` command.

Smaller changes included in this PR are:
  * bump default cloud image to ubuntu-18.04
  * explicitly disable the deployment of helm and the static local volume provisioner by kubespray
  * add crs4's helm chart repository on `config-client`

