### PR TITLE
Feature/tag worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ For additional functionality see the output from `manage-cluster -h`:
     deploy-k8s     deploys kubernetes
     config-cluster customize cluster with CRS4-specific configuration
     destroy        destroys virtual machines
-    config         configures kubectl
+    config-client  configures kubectl
+    get-master-ips prints out master IPs for the cluster, one per line (cluster must be deployed)
     shell          opens a shell in the manage-cluster container
 
   CLUSTER_DIR:

--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -81,6 +81,9 @@
   shell: kubectl apply -f "{{ item.path }}"
   loop: "{{ k8s_resources.files | list }}"
 
+- name: Label worker nodes
+  shell: for node in $(kubectl get nodes -l node-role.kubernetes.io/node='' -o name ); do kubectl label ${node} tdm.role.worker='' ; done
+
 ####### Install tiller on cluster
 - name: print message
   debug:

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -461,9 +461,9 @@ END
   docker_run_tf terraform destroy -var-file=cluster.tf ../../contrib/terraform/openstack
 
   # remove the master IP from the known hosts file, if it's there
-  for master in "${master_ips[*]}"; do
-    debug_log "Removing local host key for master node ${master}"
-    ssh-keygen -R ${master} && true
+  for master in "${master_ips[@]}"; do
+    debug_log "Removing local host key for master node ${master}, if present"
+    ssh-keygen -R ${master} || true
   done
 }
 


### PR DESCRIPTION
This PR labels the worker nodes when running `config-cluster` and fixes a problem with the removal of the master IP addresses from the local host key cache. 