### PR TITLE
Feature/masters on external network

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM hashicorp/terraform:0.11.11 AS manage-cluster-base
 #ARG kubespray_version="v2.8.2"
 
 ARG git_repo=tdm-project/kubespray.git
-ARG kubespray_version="v2.8.2_anti_affinity"
+ARG kubespray_version="v2.8.4_masters_on_external_network"
 
 LABEL kubespray_version="${kubespray_version}"
 

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -200,6 +200,7 @@ number_of_etcd = 0
 
 # masters
 number_of_k8s_masters = 0
+number_of_k8s_masters_ext_net = 0
 number_of_k8s_masters_no_etcd = 0
 number_of_k8s_masters_no_floating_ip = 0
 number_of_k8s_masters_no_floating_ip_no_etcd = 0

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -22,7 +22,7 @@ set -o pipefail
 set -o errtrace
 
 # sw version
-VERSION=1.3rc1
+VERSION=1.4rc1
 # set version of docker images
 KsImage="${KsImage:-tdmproject/manage-cluster-ks:${VERSION}}"
 TfImage="${TfImage:-tdmproject/manage-cluster-tf:${VERSION}}"

--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -199,7 +199,10 @@ flavor_bastion = "0298dfce-aa0f-45d0-91a6-ca8ac2313d94"
 number_of_etcd = 0
 
 # masters
+## regular masters are assigned a floating IP
 number_of_k8s_masters = 0
+## masters_ext_net are masters with a second interface on the external network
+## (IP set via DHCP) and no floating IP
 number_of_k8s_masters_ext_net = 0
 number_of_k8s_masters_no_etcd = 0
 number_of_k8s_masters_no_floating_ip = 0


### PR DESCRIPTION
This PR points our Docker image to a modified version of kubespray that includes the ability to create master nodes with an additional network interface directly attached to an OpenStack external network.