### PR TITLE
Use jq command from container image

### DIFF
--- a/k8s-tools/manage-cluster
+++ b/k8s-tools/manage-cluster
@@ -290,7 +290,8 @@ function get_tf_json() {
 }
 
 function _get_master_ips_internal() {
-  get_tf_json | jq '.k8s_master_fips.value[]' | tr '"\n' ' '
+  # Run entire command in container to avoid requiring jq on client machine
+  docker_run_tf /bin/bash -c "terraform output -json | jq '.k8s_master_fips.value[]' | tr '\"\n' ' '"
 }
 
 function copy_certs() {


### PR DESCRIPTION
This PR removes the requirement of `jq` on the client machine.  We use it to parse the Terraform state to get the master IP addresses.