### PR TITLE
Identify worker nodes by name in config-cluster playbook

### DIFF
--- a/docker/config-cluster/tasks/k8s-deployment-config.yml
+++ b/docker/config-cluster/tasks/k8s-deployment-config.yml
@@ -157,7 +157,7 @@
   loop: "{{ k8s_resources.files | list }}"
 
 - name: Label worker nodes
-  shell: for node in $(kubectl get nodes -l node-role.kubernetes.io/node='' -o name ); do kubectl label --overwrite ${node} tdm.role.worker='' ; done
+  shell: for node in $(kubectl get nodes -o name | grep -v master ); do kubectl label --overwrite ${node} tdm.role.worker='' ; done
 
 - name: Label data nodes
   shell: for node in $(kubectl get nodes -o name | grep data-node ); do kubectl label --overwrite ${node} tdm.role.datanode='' ; done


### PR DESCRIPTION
Newer versions of kubespray don't set a "node" role label on the worker
nodes.  This change makes the playbook identify them by name instead when setting node labels.